### PR TITLE
ci(.github): add claude-review and report on merge-queue refs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,12 @@ name: Build
 
 on:
   pull_request: {}
+  # The merge queue needs `build` and `Lint PR title` to report on the
+  # queue ref. merge_group alone was not dispatching, so mirror the
+  # push-on-queue-ref trigger the review workflows already use.
+  push:
+    branches:
+      - gh-readonly-queue/**
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,27 @@
+name: Claude Code Review
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+  push:
+    branches:
+      - gh-readonly-queue/**
+  merge_group: {}
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping review in queue context"
+      - name: Run claude review
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        continue-on-error: true
+        uses: p6m7g8-actions/claude@main
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -9,6 +9,10 @@ on:
       - reopened
       - ready_for_review
       - edited
+  push:
+    branches:
+      - gh-readonly-queue/**
+  merge_group: {}
 
 jobs:
   lint:
@@ -17,7 +21,11 @@ jobs:
     permissions:
       pull-requests: read
     steps:
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping lint in queue context"
       - name: Lint PR title
+        if: github.event_name == 'pull_request_target'
         uses: p6m7g8-actions/p6-gh-pr-title-linter@main
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What:** Add `claude-review.yml` (verbatim from the canonical distributor pack), add the `push: gh-readonly-queue/**` rider to `build.yml`, and bring `pull-request-lint.yml` up to the current generation so all three required checks can report on merge-queue refs. `codex-review.yml` is deliberately not added.

**Why:** This repo's ruleset requires `build`, `Lint PR title` and `claude-review`, but the repo had no `claude-review.yml` at all. That check could never report, so every PR here was permanently unmergeable. Verified against the live ruleset:

```
required_status_checks: ["Lint PR title", "build", "claude-review"]
```

**Root cause of the drift:** this repo is absent from `p6-gh-distributor/repos/p6m7g8-actions.txt`. All 35 action repos are listed; the org profile repo is not. So it never received `claude-review.yml`, and its `build.yml` and `pull-request-lint.yml` are both an older generation than everywhere else. This will not self-heal on the next distribution run, which is why it is fixed by hand here.

**Scope correction — `pull-request-lint.yml` had to be included.** The `build.yml` rider plus `claude-review.yml` alone would *not* have made this repo mergeable. On `main`, `pull-request-lint.yml` triggers on `pull_request_target` only, so `Lint PR title` would never have reported on the queue ref and the PR would still have been dequeued at the 7-minute check timeout — the same failure the rider exists to prevent. The premise that `pull-request-lint.yml` already carries the trigger everywhere holds for the 35 distributed repos but not for this one. It is now the canonical `workflow_files/common/pull-request-lint.yml`, byte-identical, including the `Skip on queue refs` guard and the `pull_request_target` gate on the lint step.

Coverage after this change, computed from the workflow files:

| Required check | Reports on PR ref | Reports on queue ref | Source |
|---|---|---|---|
| `build` | yes | yes | `build.yml` |
| `Lint PR title` | yes | yes | `pull-request-lint.yml` |
| `claude-review` | yes | yes | `claude-review.yml` |

Both `claude-review.yml` and `build.yml` run from the PR head on `pull_request`, so this PR satisfies its own required checks and self-heals the repo.

**`codex-review.yml` deliberately untouched.** Not added, per the retirement of Codex (196 workflows disabled, dropped from 66 rulesets, removed from the distributed pack, action repo archived). The repo does already contain a stale `codex-review.yml` from #20, which I left in place: it is not a required check here so it cannot block the queue, and every distributed repo still carries the same stale file, since removing a file from the pack does not delete it downstream. Cleaning those up is one org-wide sweep, not a change that belongs in this PR.

**Test plan:**
- Confirmed the live ruleset's three required contexts via `gh api repos/p6m7g8-actions/.github/rulesets`.
- Confirmed `claude-review.yml` is byte-identical to both `p6-gh-release/.github/workflows/claude-review.yml` and `p6-gh-distributor/workflow_files/common/claude-review.yml`, and that it contains the `push: branches: [gh-readonly-queue/**]` trigger.
- Confirmed `pull-request-lint.yml` is byte-identical to `p6-gh-distributor/workflow_files/common/pull-request-lint.yml`.
- Parsed all three workflows and derived the coverage table above programmatically; also verified from `origin/main` that `Lint PR title` had no queue-ref coverage before this PR.
- `actionlint .github/workflows/*.yml` clean.
- `python3 -c "import yaml; yaml.safe_load(...)"` on all three files.
- Both `run:` blocks (the two `Skip on queue refs` steps) extracted and `shellcheck -S warning -s bash`-ed: clean.
- `yamllint` (max 120, warning): warnings only, exit 0. `cspell`: 0 issues. `markdownlint '**/*.md'` with the linter's real 120-column config: exit 0, so no pre-existing markdown debt.
- Empirical basis for the rider: the last `merge_group` run anywhere in this org was 2026-03-09, while `push` runs on `gh-readonly-queue/**` refs are still firing today. In `p6-gh-release`, which already carries the rider, `Build` runs on queue refs and succeeds.
- `act` skipped: it fails pre-push at `actions/checkout` with `upload-pack: not our ref` because the checkout wrapper fetches the commit by SHA from the remote before it exists there. Reproduced once in this wave; relying on the remote run.

**Dependencies:** Depends on Wave 1 (all merged).
